### PR TITLE
Fix repo when is none

### DIFF
--- a/github_stats.py
+++ b/github_stats.py
@@ -305,6 +305,9 @@ Languages:
                      + owned_repos.get("nodes", []))
 
             for repo in repos:
+                if(repo is None):
+                    continue
+                    
                 name = repo.get("nameWithOwner")
                 if name in self._repos or name in self._exclude_repos:
                     continue


### PR DESCRIPTION
Error:
AttributeError: 'NoneType' object has no attribute 'get'